### PR TITLE
feat(bot): Change `=userinfo` and `=serverinfo` to use discord timestamps

### DIFF
--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -60,9 +60,9 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Avatar", f"[Link]({member.avatar_url_as(static_format='png')})")
         embed.add_field(
             "Joined Server",
-            member.joined_at.replace(microsecond=0) if member.joined_at else "Unknown",
+            f"<t:{round(member.joined_at.replace(microsecond=0).timestamp())}:R>" if member.joined_at else "Unknown",
         )
-        embed.add_field("Account Created", member.created_at.replace(microsecond=0))
+        embed.add_field("Account Created", f"<t:{round(member.created_at.replace(microsecond=0).timestamp())}:R>")
         embed.add_field(
             "Roles",
             f"{len(roles)} roles" if len(", ".join(roles)) > 1000 else ", ".join(roles),
@@ -88,7 +88,7 @@ class Miscellaneous(commands.Cog):
             "Icon",
             f"[Link]({guild.icon_url_as(static_format='png')})" if guild.icon else "*Not set*",
         )
-        embed.add_field("Server Created", guild.created_at.replace(microsecond=0))
+        embed.add_field("Server Created", f"<t:{round(guild.created_at.replace(microsecond=0).timestamp())}:R>")
         embed.add_field("Members", guild.member_count)
         embed.add_field("Channels", str(len(await guild.channels())))
         embed.add_field("Roles", str(len(await guild.roles())))


### PR DESCRIPTION
**Summary**
I changed `=userinfo` and `=serverinfo` from using plain text, to using discord formatted relative timestamps.

**Related issue(s)**
[Suggestion #598](https://discord.com/channels/576016832956334080/576765354051633178/1200407804272459828)

**Additional context**
N/A
